### PR TITLE
Member 해시태그에 inline-block 설정

### DIFF
--- a/src/components/luna/MemberItem.vue
+++ b/src/components/luna/MemberItem.vue
@@ -63,6 +63,7 @@ export default class LUNA_MemberItem extends Vue {
     span {
       margin-right: 5px;
       word-break: keep-all;
+      display: inline-block;
     }
   }
   &-desc {

--- a/src/pages/Main.vue
+++ b/src/pages/Main.vue
@@ -20,7 +20,7 @@ export default class Main extends Vue {
   private bgHeight = 0;
   private mounted() {
     const setBgHeight = () => {
-      if(this.$refs.bg) {
+      if (this.$refs.bg) {
         const bgEle = document.getElementById('main_bg') as HTMLElement;
         this.bgHeight = bgEle.clientHeight - 2;
         setTimeout(setBgHeight, 100);


### PR DESCRIPTION
변경 전 | 변경 후
------ | ------
![old](https://user-images.githubusercontent.com/32605822/52334619-783dc400-2a43-11e9-859e-22e9adbba2c7.png)|![new](https://user-images.githubusercontent.com/32605822/52334621-796ef100-2a43-11e9-9646-eda5f807a870.png)

왼쪽 위 스크린샷과 같이 각 MemberItem의 해시태그가 `display: inline`으로 나타나, 일부 선배님들의 프로필 해시태그에서 넘버 사인과 태그 내용이 각각 다른 줄에 나타나는 경우가 있었습니다. 
`display: inline-block`을 통해서 조금 더 알맞은 줄바꿈을 제공하면 어떨까 하는 생각이 들어서 PR하게 되었습니다!
항상 감사합니다. 😚